### PR TITLE
Add a `get_version()` utility to provide theme version.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,9 +1,9 @@
 <?php
 
-if ( ! defined( '_S_VERSION' ) ) {
-	// Replace the version number of the theme on each release.
-	define( '_S_VERSION', '1.0.0' );
-}
+/**
+ * Load general utilities available in the theme.
+ */
+require_once __DIR__ . '/includes/utilities.php';
 
 /**
  * Load general theme setup hooks.

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -40,7 +40,13 @@ function customize_register( $wp_customize ) {
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function customize_preview_js() {
-	wp_enqueue_script( 'themeprefix-customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), _S_VERSION, true );
+	wp_enqueue_script(
+		'themeprefix-customizer',
+		get_template_directory_uri() . '/js/customizer.js',
+		array( 'customize-preview' ),
+		\ThemeMainNamespace\Utilities\get_version(),
+		true
+	);
 }
 
 /**

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -5,7 +5,6 @@
 
 namespace ThemeMainNamespace\TemplateTags;
 
-
 /**
  * Prints HTML with meta information for the current post-date/time.
  */

--- a/includes/theme-setup.php
+++ b/includes/theme-setup.php
@@ -124,10 +124,21 @@ function widgets_init() {
  * Enqueue scripts and styles.
  */
 function enqueue_assets() {
-	wp_enqueue_style( 'themeprefix-style', get_stylesheet_uri(), array(), _S_VERSION );
+	wp_enqueue_style(
+		'themeprefix-style',
+		get_stylesheet_uri(),
+		array(),
+		\ThemeMainNamespace\Utilities\get_version()
+	);
 	wp_style_add_data( 'themeprefix-style', 'rtl', 'replace' );
 
-	wp_enqueue_script( 'themeprefix-navigation', get_template_directory_uri() . '/js/navigation.js', array(), _S_VERSION, true );
+	wp_enqueue_script(
+		'themeprefix-navigation',
+		get_template_directory_uri() . '/js/navigation.js',
+		array(),
+		\ThemeMainNamespace\Utilities\get_version(),
+		true
+	);
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ThemeMainNamespace\Utilities;
+
+/**
+ * Retrieve the theme's version number.
+ *
+ * @return string Current theme version number.
+ */
+function get_version() {
+	$version = wp_get_theme()->version;
+
+	return $version;
+}


### PR DESCRIPTION
This reduces the number of places in which the version number needs to be changed. If for some reason the version number is ever required earlier than `wp_get_theme()` is available, then it can be replaced with a static string.